### PR TITLE
Slabbed toggle + raytrace fix POC

### DIFF
--- a/src/main/java/com/slabbed/Slabbed.java
+++ b/src/main/java/com/slabbed/Slabbed.java
@@ -1,12 +1,15 @@
 package com.slabbed;
 
 import net.fabricmc.api.ModInitializer;
+import net.minecraft.state.property.BooleanProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Slabbed implements ModInitializer {
     public static final String MOD_ID = "slabbed";
     public static final Logger LOGGER = LoggerFactory.getLogger(Slabbed.class);
+
+    public static final BooleanProperty IS_SLABBED = BooleanProperty.of("is_slabbed");
 
     @Override
     public void onInitialize() {

--- a/src/main/java/com/slabbed/mixin/EntityInvoker.java
+++ b/src/main/java/com/slabbed/mixin/EntityInvoker.java
@@ -1,0 +1,20 @@
+package com.slabbed.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(Entity.class)
+public interface EntityInvoker
+{
+    @Invoker("getCameraPosVec")
+    Vec3d slabbed$getCameraPosVec(float tickProgress);
+
+    @Invoker("getRotationVec")
+    Vec3d slabbed$getRotationVec(float tickProgress);
+
+    @Invoker("getEntityWorld")
+    World slabbed$getEntityWorld();
+}

--- a/src/main/java/com/slabbed/mixin/EntityMixin.java
+++ b/src/main/java/com/slabbed/mixin/EntityMixin.java
@@ -50,9 +50,6 @@ public abstract class EntityMixin implements EntityInvoker
 
         HitResult returnValue = cir.getReturnValue();
 
-        final double miss = 0.02;
-        final double hit = 0.05;
-
         if (returnValue.getPos().distanceTo(cameraPos) > highResult.getPos().distanceTo(cameraPos))
         {
             cir.setReturnValue(highResult);

--- a/src/main/java/com/slabbed/mixin/EntityMixin.java
+++ b/src/main/java/com/slabbed/mixin/EntityMixin.java
@@ -1,0 +1,158 @@
+package com.slabbed.mixin;
+
+import com.slabbed.util.SlabSupport;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.*;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.RaycastContext;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+@Mixin(Entity.class)
+public abstract class EntityMixin implements EntityInvoker
+{
+    @Inject(method = "raycast", at = @At(value = "RETURN"), cancellable = true)
+    public void slabbed$raycast(double maxDistance, float tickProgress, boolean includeFluids, CallbackInfoReturnable<HitResult> cir)
+    {
+        Vec3d cameraPos = slabbed$getCameraPosVec(tickProgress).add(0, 0.5, 0);
+        Vec3d vec3d2 = slabbed$getRotationVec(tickProgress);
+        Vec3d vec3d3 = cameraPos.add(vec3d2.x * maxDistance, vec3d2.y * maxDistance, vec3d2.z * maxDistance);
+        World world = slabbed$getEntityWorld();
+
+        HitResult highResult = raycast(
+            world,
+            new RaycastContext(
+                cameraPos,
+                vec3d3,
+                RaycastContext.ShapeType.OUTLINE,
+                includeFluids ? RaycastContext.FluidHandling.ANY : RaycastContext.FluidHandling.NONE,
+                (Entity) (Object) this)
+        );
+
+        if (!(highResult instanceof BlockHitResult bhr))
+        {
+            return;
+        } else if (!SlabSupport.shouldOffset(world, bhr.getBlockPos(), world.getBlockState(bhr.getBlockPos())))
+        {
+            return;
+        }
+
+        HitResult returnValue = cir.getReturnValue();
+
+        final double miss = 0.02;
+        final double hit = 0.05;
+
+        if (returnValue.getPos().distanceTo(cameraPos) > highResult.getPos().distanceTo(cameraPos))
+        {
+            cir.setReturnValue(highResult);
+        }
+    }
+
+    private static BlockHitResult raycast(BlockView blockView, RaycastContext context)
+    {
+        return raycast(context.getStart(), context.getEnd(), context, (innerContext, pos) ->
+        {
+            BlockState blockState = blockView.getBlockState(pos);
+            FluidState fluidState = blockView.getFluidState(pos);
+            Vec3d vec3d = innerContext.getStart();
+            Vec3d vec3d2 = innerContext.getEnd();
+            VoxelShape voxelShape = innerContext.getBlockShape(blockState, blockView, pos);
+            double yOff = SlabSupport.getYOffset(blockView, pos, blockState);
+            if (yOff != 0.0) {
+                voxelShape = voxelShape.offset(0, -yOff, 0);
+            }
+            BlockHitResult blockHitResult = blockView.raycastBlock(vec3d, vec3d2, pos, voxelShape, blockState);
+            VoxelShape voxelShape2 = innerContext.getFluidShape(fluidState, blockView, pos);
+            BlockHitResult blockHitResult2 = voxelShape2.raycast(vec3d, vec3d2, pos);
+            double d = blockHitResult == null ? Double.MAX_VALUE : innerContext.getStart().squaredDistanceTo(blockHitResult.getPos());
+            double e = blockHitResult2 == null ? Double.MAX_VALUE : innerContext.getStart().squaredDistanceTo(blockHitResult2.getPos());
+            return d <= e ? blockHitResult : blockHitResult2;
+        }, innerContext ->
+        {
+            Vec3d vec3d = innerContext.getStart().subtract(innerContext.getEnd());
+            return BlockHitResult.createMissed(innerContext.getEnd(), Direction.getFacing(vec3d.x, vec3d.y, vec3d.z), BlockPos.ofFloored(innerContext.getEnd()));
+        });
+    }
+
+    private static <T, C> T raycast(Vec3d start, Vec3d end, C context, BiFunction<C, BlockPos, T> blockHitFactory, Function<C, T> missFactory)
+    {
+        if (start.equals(end))
+        {
+            return missFactory.apply(context);
+        } else
+        {
+            double d = MathHelper.lerp(-1.0E-7, end.x, start.x);
+            double e = MathHelper.lerp(-1.0E-7, end.y, start.y);
+            double f = MathHelper.lerp(-1.0E-7, end.z, start.z);
+            double g = MathHelper.lerp(-1.0E-7, start.x, end.x);
+            double h = MathHelper.lerp(-1.0E-7, start.y, end.y);
+            double i = MathHelper.lerp(-1.0E-7, start.z, end.z);
+            int j = MathHelper.floor(g);
+            int k = MathHelper.floor(h);
+            int l = MathHelper.floor(i);
+            BlockPos.Mutable mutable = new BlockPos.Mutable(j, k, l);
+            T object = (T) blockHitFactory.apply(context, mutable);
+            if (object != null)
+            {
+                return object;
+            } else
+            {
+                double m = d - g;
+                double n = e - h;
+                double o = f - i;
+                int p = MathHelper.sign(m);
+                int q = MathHelper.sign(n);
+                int r = MathHelper.sign(o);
+                double s = p == 0 ? Double.MAX_VALUE : p / m;
+                double t = q == 0 ? Double.MAX_VALUE : q / n;
+                double u = r == 0 ? Double.MAX_VALUE : r / o;
+                double v = s * (p > 0 ? 1.0 - MathHelper.fractionalPart(g) : MathHelper.fractionalPart(g));
+                double w = t * (q > 0 ? 1.0 - MathHelper.fractionalPart(h) : MathHelper.fractionalPart(h));
+                double x = u * (r > 0 ? 1.0 - MathHelper.fractionalPart(i) : MathHelper.fractionalPart(i));
+
+                while (v <= 1.0 || w <= 1.0 || x <= 1.0)
+                {
+                    if (v < w)
+                    {
+                        if (v < x)
+                        {
+                            j += p;
+                            v += s;
+                        } else
+                        {
+                            l += r;
+                            x += u;
+                        }
+                    } else if (w < x)
+                    {
+                        k += q;
+                        w += t;
+                    } else
+                    {
+                        l += r;
+                        x += u;
+                    }
+
+                    T object2 = blockHitFactory.apply(context, mutable.set(j, k, l));
+                    if (object2 != null)
+                    {
+                        return object2;
+                    }
+                }
+
+                return missFactory.apply(context);
+            }
+        }
+    }
+}

--- a/src/main/java/com/slabbed/mixin/SlabBlockMixin.java
+++ b/src/main/java/com/slabbed/mixin/SlabBlockMixin.java
@@ -41,7 +41,6 @@ public abstract class SlabBlockMixin extends Block
     @Override
     protected ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit)
     {
-        Thread.dumpStack();
         if (player.isSneaking())
         {
             boolean newState = !state.get(Slabbed.IS_SLABBED);

--- a/src/main/java/com/slabbed/mixin/SlabBlockMixin.java
+++ b/src/main/java/com/slabbed/mixin/SlabBlockMixin.java
@@ -1,0 +1,69 @@
+package com.slabbed.mixin;
+
+import com.slabbed.Slabbed;
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.SlabBlock;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.particle.DustParticleEffect;
+import net.minecraft.state.StateManager;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(SlabBlock.class)
+public abstract class SlabBlockMixin extends Block
+{
+    private SlabBlockMixin(Settings settings)
+    {
+        super(settings);
+    }
+
+    @Inject(method = "<init>", at = @At(value = "TAIL"))
+    public void slabbed$SlabBlock(AbstractBlock.Settings settings, CallbackInfo info)
+    {
+        setDefaultState(getDefaultState().with(Slabbed.IS_SLABBED, false));
+    }
+
+    @Inject(method = "appendProperties", at = @At(value = "TAIL"))
+    public void slabbed$appendProperties(StateManager.Builder<Block, BlockState> builder, CallbackInfo info)
+    {
+        builder.add(Slabbed.IS_SLABBED);
+    }
+
+    @Override
+    protected ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit)
+    {
+        Thread.dumpStack();
+        if (player.isSneaking())
+        {
+            boolean newState = !state.get(Slabbed.IS_SLABBED);
+            world.setBlockState(pos, state.with(Slabbed.IS_SLABBED, newState), 3);
+
+            Random random = world.getRandom();
+
+            for (int i = 0; i < 16; ++i)
+            {
+                double h = random.nextGaussian() * 0.02;
+                double j = random.nextGaussian() * 0.02;
+                double k = random.nextGaussian() * 0.02;
+                int color = newState ? 0x00ff00 : 0xff0000;
+                world.addParticleClient(
+                    new DustParticleEffect(color, 0.92f),
+                    pos.getX() + random.nextDouble() * 1.2, pos.getY() + random.nextDouble() * 1.2, pos.getZ() + random.nextDouble() * 1.2,
+                    h, j, k);
+            }
+
+            return ActionResult.SUCCESS;
+        }
+
+        return super.onUse(state, world, pos, player, hit);
+    }
+}

--- a/src/main/java/com/slabbed/util/SlabSupport.java
+++ b/src/main/java/com/slabbed/util/SlabSupport.java
@@ -1,5 +1,6 @@
 package com.slabbed.util;
 
+import com.slabbed.Slabbed;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.FenceBlock;
@@ -44,7 +45,7 @@ public final class SlabSupport {
      * Returns true if the state is a slab with a defined type.
      */
     public static boolean isSupportingSlab(BlockState state) {
-        return state.getBlock() instanceof SlabBlock && state.contains(SlabBlock.TYPE);
+        return state.getBlock() instanceof SlabBlock && state.contains(SlabBlock.TYPE) && state.get(Slabbed.IS_SLABBED);
     }
 
     /** True if this state is a bottom slab. */

--- a/src/main/resources/slabbed.mixins.json
+++ b/src/main/resources/slabbed.mixins.json
@@ -7,6 +7,8 @@
     "SlabSupportStateMixin",
     "TorchParticleMixin",
     "RedstoneWireBlockMixin",
+    "EntityInvoker",
+    "EntityMixin",
     "SlabBlockMixin"
   ],
   "client": [],

--- a/src/main/resources/slabbed.mixins.json
+++ b/src/main/resources/slabbed.mixins.json
@@ -6,7 +6,8 @@
     "SlabSupportBlockMixin",
     "SlabSupportStateMixin",
     "TorchParticleMixin",
-    "RedstoneWireBlockMixin"
+    "RedstoneWireBlockMixin",
+    "SlabBlockMixin"
   ],
   "client": [],
   "injectors": { "defaultRequire": 1 }


### PR DESCRIPTION
Adds 1 new feature and 1 fix.

Sneak right clicking a slab will toggle a custom block property "is_slabbed". Slabs with this property set to true will enable the mod functionality. Otherwise the slabs behave just like vanilla slabs.
Here I'd recommend a config to enable/disable the toggle functionality and a config which would choose the default state.
<img width="1920" height="1017" alt="image" src="https://github.com/user-attachments/assets/2ebf793d-f7da-4d73-807a-dad651069860" />
Image of the left slab having the functionality enabled and the right one disabled.


Proof of concept for the raytrace fix. Currently looking throught what would be a gap in the slab block works as vanilla would - You'd look at the block behind. This fix... fixes that as you can see in the image below. I have not found a scenario where this can break, but I don't rule out the existence of it.
<img width="1920" height="1017" alt="image" src="https://github.com/user-attachments/assets/73072c3f-dfed-46e2-9294-7a601f541ac5" />

I don't recommend actually taking the exact code for the PoC, it was done hastily and I feel like there should be a better way. For example not copy pasting a whole method. Also I just didn't follow your styling. I just wanted to share my findings and suggestions :)